### PR TITLE
feat: support dotfiles in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,35 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:20
 
-ARG DEBIAN_FRONTEND=noninteractive
-
-## Fish - https://github.com/fish-shell/fish-shell ##
-RUN echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_11/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list && \
-	curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_11/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null && \
-	apt update -y && \
-	apt install fish -y
-
-ENV SHELL=/usr/bin/fish LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
-
-## Starship - https://github.com/starship/starship ##
-RUN mkdir /home/node/.config && \
-	mkdir /home/node/.config/fish && \
-	chown -R node /home/node/.config && \
-	curl -fsSL https://starship.rs/install.sh | sh -s -- -y && \
-	echo "starship init fish | source" >> /home/node/.config/fish/config.fish && \
-	starship preset plain-text-symbols -o /home/node/.config/starship.toml
-
-## Buf - https://github.com/bufbuild/buf ##
-RUN curl -sSL \
-    	"https://github.com/bufbuild/buf/releases/download/v1.17.0/buf-$(uname -s)-$(uname -m)" \
-      	-o "/usr/local/bin/buf" && \
-    chmod +x "/usr/local/bin/buf" && \
-	chsh -s /usr/bin/fish
-
-## Hadolint - https://github.com/hadolint/hadolint ##
-RUN curl -sSL \
-      	"https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-$(uname -s)-$(uname -m)" \
-      	-o "/usr/local/bin/hadolint" && \
-    chmod +x "/usr/local/bin/hadolint"
-
 RUN su node -c "npm i @sapphire/cli -g" && \
 	su node -c "npm i -g turbo"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,17 @@
 	"service": "workspace",
 	"workspaceFolder": "/KBot",
 	"remoteUser": "node",
-	"dockerComposeFile": ["docker-compose.workspace.yml", "../apps/bot/docker-compose.dev.yml"],
+	"dockerComposeFile": [
+		"docker-compose.workspace.yml", //
+		"../apps/bot/docker-compose.dev.yml"
+	],
 	"customizations": {
 		"vscode": {
+			"settings": {
+				"dotfiles.repository": "${localEnv:DOTFILES_REPO}",
+				"dotfiles.targetPath": "~/dotfiles",
+				"dotfiles.installCommand": "~/dotfiles/install.sh"
+			},
 			"extensions": [
 				"bufbuild.vscode-buf",
 				"EditorConfig.EditorConfig",
@@ -18,7 +26,8 @@
 				"bradlc.vscode-tailwindcss",
 				"zxh404.vscode-proto3",
 				"redhat.vscode-yaml",
-				"ms-kubernetes-tools.vscode-kubernetes-tools"
+				"ms-kubernetes-tools.vscode-kubernetes-tools",
+				"github.vscode-github-actions"
 			]
 		}
 	},


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Devcontainers previously forced the user to use `fish` and `starship`. Now with dotfiles being supported they user can provide whatever config they want.